### PR TITLE
Harden media review and polish the interface

### DIFF
--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -8,7 +8,7 @@ import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { ArrClient, ArrError } from "./arr.ts";
 import { loadOrFetchPoster, sniffImageType } from "./art.ts";
-import type { ArrKind } from "./models.ts";
+import type { ArrKind, ExclusionKind } from "./models.ts";
 import { clientIp, isPrivateIp } from "./net.ts";
 import { Store, publicSettings } from "./store.ts";
 import { Catalog, type ProbeFn } from "./catalog.ts";
@@ -528,6 +528,7 @@ export function createApp(store: Store, opts?: AppOpts): App {
   app.post("/api/exclusions", requireAuth, async (c) => {
     const body = (await c.req.json().catch(() => ({}))) as { kind?: string; value?: string };
     if (!body.kind || !body.value) return c.json({ error: "kind and value required" }, 400);
+    if (!isExclusionKind(body.kind)) return c.json({ error: "kind must be path, profile, tag, or title" }, 400);
     store.addExclusion(body.kind, body.value);
     return c.json({ ok: true }, 201);
   });
@@ -658,4 +659,6 @@ function storageTestDetail(method: string): string {
   return "Copied through this host. Configure NAS SSH to keep the bytes on the NAS.";
 }
 
-
+function isExclusionKind(value: string): value is ExclusionKind {
+  return value === "path" || value === "profile" || value === "tag" || value === "title";
+}

--- a/src/server/arr.ts
+++ b/src/server/arr.ts
@@ -17,6 +17,7 @@ export type RemoteItem = {
   hdr: string | null;
   size: number | null;
   posterRemoteUrl: string | null;
+  tags: string[];
 };
 
 export class ArrError extends Error {
@@ -40,11 +41,13 @@ export class ArrClient {
 
   async listMovies(instance: ArrInstance): Promise<RemoteItem[]> {
     const rows = await this.getJsonArray(`${instance.url}/api/v3/movie`, instance.apiKey);
-    return rows.map((raw) => withResolvedPoster(parseMovie(raw), instance.url));
+    const tags = await this.listTagNames(instance);
+    return rows.map((raw) => withResolvedPoster(resolveTagNames(parseMovie(raw), tags), instance.url));
   }
 
   async listEpisodes(instance: ArrInstance): Promise<RemoteItem[]> {
     const series = await this.getJsonArray(`${instance.url}/api/v3/series`, instance.apiKey);
+    const tags = await this.listTagNames(instance);
     const out: RemoteItem[] = [];
     for (const show of series) {
       const seriesId = Number(show.id);
@@ -68,7 +71,10 @@ export class ArrClient {
         const attached = episodeFilePath(ep)
           ? ep
           : { ...ep, episodeFile: filesById.get(Number(ep.episodeFileId)) ?? ep.episodeFile };
-        const parsed = parseEpisode(attached, title, seriesId, seriesPoster);
+        const parsed = resolveTagNames(
+          parseEpisode(attached, title, seriesId, seriesPoster, stringList(show.tags)),
+          tags,
+        );
         if (parsed) {
           if (!parsed.folderPath) parsed.folderPath = folderPath;
           out.push(withResolvedPoster(parsed, instance.url));
@@ -92,6 +98,15 @@ export class ArrClient {
       throw new ArrError(`Arr returned HTTP ${res.status}`);
     }
     return res.json();
+  }
+
+  private async listTagNames(instance: ArrInstance): Promise<Map<string, string>> {
+    try {
+      const rows = await this.getJsonArray(`${instance.url}/api/v3/tag`, instance.apiKey);
+      return new Map(rows.map((row) => [String(row.id), String(row.label ?? row.id)]));
+    } catch {
+      return new Map();
+    }
   }
 
   private async getJsonArray(url: string, apiKey: string): Promise<Record<string, unknown>[]> {
@@ -123,6 +138,7 @@ export function parseMovie(raw: Record<string, unknown>): RemoteItem {
     hdr: hdrOf(mediaInfo),
     size: typeof movieFile.size === "number" ? movieFile.size : null,
     posterRemoteUrl: posterUrlFromImages(raw.images),
+    tags: stringList(raw.tags),
   };
 }
 
@@ -180,6 +196,7 @@ export function parseEpisode(
   seriesTitle: string,
   seriesId: number | null = null,
   seriesPoster: string | null = null,
+  seriesTags: string[] = [],
 ): RemoteItem | null {
   const episodeFile = (raw.episodeFile ?? {}) as Record<string, unknown>;
   const filePath = typeof episodeFile.path === "string" ? episodeFile.path : "";
@@ -206,7 +223,22 @@ export function parseEpisode(
     hdr: hdrOf(mediaInfo),
     size: typeof episodeFile.size === "number" ? episodeFile.size : null,
     posterRemoteUrl: seriesPoster ?? posterUrlFromImages(raw.images),
+    tags: [...new Set([...seriesTags, ...stringList(raw.tags)])],
   };
+}
+
+function resolveTagNames(item: RemoteItem, names: Map<string, string>): RemoteItem;
+function resolveTagNames(item: null, names: Map<string, string>): null;
+function resolveTagNames(item: RemoteItem | null, names: Map<string, string>): RemoteItem | null {
+  if (!item) return null;
+  return { ...item, tags: item.tags.map((tag) => names.get(tag) ?? tag) };
+}
+
+function stringList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((entry): entry is string | number => typeof entry === "string" || typeof entry === "number")
+    .map(String);
 }
 
 function normalizeUrl(url: string): string {

--- a/src/server/catalog.test.ts
+++ b/src/server/catalog.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { ArrClient } from "./arr.ts";
 import { createApp } from "./app.ts";
-import { Catalog } from "./catalog.ts";
+import { Catalog, isFailedInspection } from "./catalog.ts";
 import { parseFfprobe } from "./inspect.ts";
 import { Store } from "./store.ts";
 import { LibrarySync } from "./sync.ts";
@@ -211,6 +211,19 @@ describe("phase 3 catalog", () => {
     store.upsertLibraryItem({ ...item!, size: 99 });
     expect(await counting.inspectPending()).toBe(1);
     expect(probed).toEqual(["/big.mkv"]);
+  });
+
+  it("marks changed media failed instead of reusing its previous inspection", async () => {
+    const { store } = await setup();
+    const item = store.listLibraryItems("movie").find((row) => row.title === "Giant AVC")!;
+    expect(isFailedInspection(store.getInspection(item.id))).toBe(false);
+    store.upsertLibraryItem({ ...item, size: 99 });
+    const catalog = new Catalog(store, () => {
+      throw new Error("ffprobe failed");
+    });
+    expect(await catalog.inspectItem(item.id)).toEqual({ onSuggestions: false, error: "Could not inspect this file." });
+    expect(isFailedInspection(store.getInspection(item.id))).toBe(true);
+    expect(store.getInspectionSig(item.id)).toBe(catalog.sourceSig(item.path, 99));
   });
 
   it("reports inspect progress on GET /api/library/inspect", async () => {

--- a/src/server/catalog.ts
+++ b/src/server/catalog.ts
@@ -71,17 +71,8 @@ export class Catalog {
     try {
       report = await this.probe(item.path);
     } catch {
-      let existing: unknown;
-      try {
-        existing = this.store.getInspection(itemId);
-      } catch {
-        return { onSuggestions: false, error: "Could not inspect this file." };
-      }
-      if (!existing || isFailedInspection(existing)) {
-        this.store.saveInspection(itemId, failedInspection(), new Date().toISOString(), sourceSig);
-        return { onSuggestions: false, error: "Could not inspect this file." };
-      }
-      report = existing as InspectionReport;
+      this.store.saveInspection(itemId, failedInspection(), new Date().toISOString(), sourceSig);
+      return { onSuggestions: false, error: "Could not inspect this file." };
     }
     this.store.saveInspection(itemId, report, new Date().toISOString(), sourceSig);
     const plan = buildSuggestion(report, this.store.getSettings(), item.type, {

--- a/src/server/jobs.test.ts
+++ b/src/server/jobs.test.ts
@@ -437,7 +437,47 @@ describe("phase 4 remux review keep", () => {
       compare: {},
     });
     const { JobService } = await import("./jobs.ts");
-    const moved: string[] = [];
+    const copied: string[] = [];
+    let renames = 0;
+    const jobs = new JobService(
+      store,
+      async () => {
+        throw new Error("unused");
+      },
+      fetch,
+      {
+        rename: async (src, dest) => {
+          renames += 1;
+          if (renames === 1) throw Object.assign(new Error("EXDEV"), { code: "EXDEV" });
+          writeFileSync(dest, readFileSync(src));
+        },
+        unlink: async () => undefined,
+        mkdir: async () => undefined,
+        stat: async () => ({ size: 1 }) as never,
+      },
+      undefined,
+      () => new Date(),
+      () => ({
+        copy: async (src, dest) => {
+          copied.push(`${src} -> ${dest}`);
+          writeFileSync(dest, "NEW");
+          return { method: "ssh", bytes: 3 };
+        },
+        move: async () => ({ method: "ssh" as const, bytes: 3 }),
+      }),
+    );
+    const result = await jobs.keep(store.listReviews()[0].id as number);
+    expect(result.ok).toBe(true);
+    expect(copied).toEqual([`${sidecar} -> ${source}.optimizarr-replacement-1`]);
+    expect(readFileSync(source, "utf8")).toBe("NEW");
+  });
+
+  it("keeps the original and sidecar when a cross-device copy stops early", async () => {
+    const { store, source, review } = await setup();
+    const item = store.listLibraryItems("movie")[0];
+    const sidecar = join(review, "x.mkv");
+    writeFileSync(sidecar, "NEW");
+    store.createReview({ itemId: item.id, jobId: 1, sourcePath: source, sidecarPath: sidecar, compare: {} });
     const jobs = new JobService(
       store,
       async () => {
@@ -455,18 +495,17 @@ describe("phase 4 remux review keep", () => {
       undefined,
       () => new Date(),
       () => ({
-        copy: async () => ({ method: "ssh" as const, bytes: 3 }),
-        move: async (src, dest) => {
-          moved.push(`${src} -> ${dest}`);
-          writeFileSync(dest, "NEW");
-          return { method: "ssh", bytes: 3 };
+        copy: async (_src, dest) => {
+          writeFileSync(dest, "PARTIAL");
+          throw new Error("connection reset");
         },
+        move: async () => ({ method: "proxy" as const, bytes: 0 }),
       }),
     );
     const result = await jobs.keep(store.listReviews()[0].id as number);
-    expect(result.ok).toBe(true);
-    expect(moved).toEqual([`${sidecar} -> ${source}`]);
-    expect(readFileSync(source, "utf8")).toBe("NEW");
+    expect(result).toMatchObject({ ok: false, error: "connection reset" });
+    expect(readFileSync(source, "utf8")).toContain("ORIGINAL");
+    expect(readFileSync(sidecar, "utf8")).toBe("NEW");
   });
 
   it("keeps both files when Keep cannot replace the original", async () => {
@@ -544,8 +583,30 @@ describe("phase 4 remux review keep", () => {
     });
   });
 
+  it("keeps a review pending when Discard cannot delete its sidecar", async () => {
+    const { store, source, review } = await setup();
+    const item = store.listLibraryItems("movie")[0];
+    const sidecar = join(review, "x.mkv");
+    writeFileSync(sidecar, "NEW");
+    store.createReview({ itemId: item.id, jobId: 1, sourcePath: source, sidecarPath: sidecar, compare: {} });
+    const jobs = new JobService(store, async () => {
+      throw new Error("unused");
+    }, fetch, {
+      rename: async () => undefined,
+      unlink: async () => {
+        throw Object.assign(new Error("permission denied"), { code: "EACCES" });
+      },
+      mkdir: async () => undefined,
+      stat: async () => ({ size: 1 }) as never,
+    });
+    expect(await jobs.discard(store.listReviews()[0].id as number)).toEqual({ ok: false, error: "permission denied" });
+    expect(store.listReviews()).toHaveLength(1);
+    expect(readFileSync(sidecar, "utf8")).toBe("NEW");
+  });
+
   it("returns Keep before a slow move finishes and rejects a second Keep", async () => {
     let release!: () => void;
+    let keepRenames = 0;
     const gate = new Promise<void>((resolve) => {
       release = resolve;
     });
@@ -556,8 +617,10 @@ describe("phase 4 remux review keep", () => {
           optimize,
           fetchImpl,
           {
-            rename: async () => {
-              throw Object.assign(new Error("EXDEV"), { code: "EXDEV" });
+            rename: async (src, dest) => {
+              keepRenames += 1;
+              if (keepRenames === 1) throw Object.assign(new Error("EXDEV"), { code: "EXDEV" });
+              writeFileSync(dest, readFileSync(src));
             },
             unlink: async () => undefined,
             mkdir: async () => undefined,
@@ -566,12 +629,12 @@ describe("phase 4 remux review keep", () => {
           undefined,
           () => new Date(),
           () => ({
-            copy: async () => ({ method: "ssh" as const, bytes: 1 }),
-            move: async (src, dest) => {
+            copy: async (src, dest) => {
               await gate;
               writeFileSync(dest, readFileSync(src));
               return { method: "ssh" as const, bytes: 1 };
             },
+            move: async () => ({ method: "ssh" as const, bytes: 1 }),
           }),
         ),
     });

--- a/src/server/jobs.ts
+++ b/src/server/jobs.ts
@@ -349,15 +349,25 @@ export class JobService {
         this.failKeep(reviewId, message);
         return { ok: false, notify: [], error: message };
       }
+      const replacementPath = `${review.sourcePath}.optimizarr-replacement-${reviewId}`;
       try {
         this.store.updateReview(reviewId, { phase: "copying", progress: 0, error: null });
-        await this.transferFor(this.store.getSettings()).move(review.sidecarPath, review.sourcePath, (copied, total) => {
+        const transfer = this.transferFor(this.store.getSettings());
+        await transfer.copy(review.sidecarPath, replacementPath, (copied, total) => {
           this.store.updateReview(reviewId, {
             phase: "copying",
             progress: total > 0 ? Math.min(copied / total, 0.99) : 0,
           });
         });
+        try {
+          await this.fs.rename(replacementPath, review.sourcePath);
+        } catch (replaceErr) {
+          await this.fs.unlink(replacementPath).catch(() => undefined);
+          throw replaceErr;
+        }
+        await this.fs.unlink(review.sidecarPath).catch(() => undefined);
       } catch (moveErr) {
+        await this.fs.unlink(replacementPath).catch(() => undefined);
         const message = moveErr instanceof Error ? moveErr.message : "Could not replace the library file";
         this.failKeep(reviewId, message);
         return { ok: false, notify: [], error: message };
@@ -388,12 +398,22 @@ export class JobService {
   async discard(reviewId: number): Promise<{ ok: boolean; error?: string }> {
     const review = this.store.getReview(reviewId);
     if (!review || review.status !== "pending") return { ok: false, error: "Review not found" };
-    await this.fs.unlink(review.sidecarPath).catch(() => undefined);
+    try {
+      await this.fs.unlink(review.sidecarPath);
+    } catch (err) {
+      if (!isMissingFile(err)) {
+        return { ok: false, error: err instanceof Error ? err.message : "Could not delete the sidecar" };
+      }
+    }
     this.store.setReviewStatus(reviewId, "discarded");
     const item = this.store.getLibraryItem(review.itemId);
     this.store.addHistory(review.itemId, item ? displayTitle(item) : "item", "discarded");
     return { ok: true };
   }
+}
+
+function isMissingFile(err: unknown): boolean {
+  return Boolean(err && typeof err === "object" && "code" in err && (err as { code: string }).code === "ENOENT");
 }
 
 function isClosedStore(err: unknown): boolean {

--- a/src/server/models.ts
+++ b/src/server/models.ts
@@ -1,6 +1,7 @@
 export type ArrKind = "radarr" | "sonarr";
 export type PlayerKind = "plex" | "jellyfin" | "other";
 export type ItemType = "movie" | "episode";
+export type ExclusionKind = "path" | "profile" | "tag" | "title";
 
 export type ArrInstance = {
   id: number;
@@ -47,6 +48,7 @@ export type LibraryItem = {
   pathError: string | null;
   updatedAt: string;
   posterRemoteUrl?: string | null;
+  tags: string[];
 };
 
 export type PublicLibraryItem = Omit<LibraryItem, "posterRemoteUrl"> & { hasPoster: boolean };

--- a/src/server/notify.test.ts
+++ b/src/server/notify.test.ts
@@ -57,6 +57,7 @@ describe("arr rename", () => {
         readable: true,
         pathError: null,
         updatedAt: "",
+        tags: [],
       },
     );
     expect(body).toEqual({ name: "RescanSeries", seriesId: 3 });

--- a/src/server/optimize.test.ts
+++ b/src/server/optimize.test.ts
@@ -139,7 +139,7 @@ describe("transcode must not silently copy", () => {
       `#!/usr/bin/env node
 const fs = require("node:fs");
 const dest = process.argv[process.argv.length - 1];
-process.stdout.write("out_time_ms=5000\\nprogress=continue\\n");
+fs.writeSync(1, "out_time_ms=5000\\nprogress=continue\\n");
 fs.mkdirSync(require("node:path").dirname(dest), { recursive: true });
 fs.writeFileSync(dest, "MEDIA");
 `,

--- a/src/server/store-exclusions.ts
+++ b/src/server/store-exclusions.ts
@@ -1,0 +1,31 @@
+import type { DatabaseSync } from "node:sqlite";
+import type { ExclusionKind, LibraryItem } from "./models.ts";
+
+export type Exclusion = { id: number; kind: ExclusionKind; value: string };
+
+export class ExclusionStore {
+  constructor(private db: DatabaseSync) {}
+
+  add(kind: ExclusionKind, value: string): void {
+    this.db.prepare("INSERT INTO exclusions (kind, value) VALUES (?, ?)").run(kind, value.trim());
+  }
+
+  list(): Exclusion[] {
+    return this.db.prepare("SELECT id, kind, value FROM exclusions ORDER BY id").all() as Exclusion[];
+  }
+
+  matches(item: Pick<LibraryItem, "title" | "path" | "quality" | "tags">): boolean {
+    return this.list().some((exclusion) => matchesExclusion(exclusion, item));
+  }
+}
+
+function matchesExclusion(
+  exclusion: Exclusion,
+  item: Pick<LibraryItem, "title" | "path" | "quality" | "tags">,
+): boolean {
+  const value = exclusion.value.toLowerCase();
+  if (exclusion.kind === "title") return item.title.toLowerCase().includes(value);
+  if (exclusion.kind === "path") return item.path.toLowerCase().includes(value);
+  if (exclusion.kind === "profile") return (item.quality ?? "").toLowerCase().includes(value);
+  return item.tags.some((tag) => tag.toLowerCase() === value);
+}

--- a/src/server/store-history.ts
+++ b/src/server/store-history.ts
@@ -1,0 +1,17 @@
+import type { DatabaseSync } from "node:sqlite";
+
+export class HistoryStore {
+  constructor(private db: DatabaseSync) {}
+
+  add(itemId: number | null, title: string, action: string, detail?: string): void {
+    this.db
+      .prepare("INSERT INTO history (item_id, title, action, detail, created_at) VALUES (?, ?, ?, ?, ?)")
+      .run(itemId, title, action, detail ?? null, new Date().toISOString());
+  }
+
+  list(): Array<Record<string, unknown>> {
+    return this.db
+      .prepare("SELECT id, item_id AS itemId, title, action, detail, created_at AS createdAt FROM history ORDER BY id DESC")
+      .all() as Array<Record<string, unknown>>;
+  }
+}

--- a/src/server/store-widget.ts
+++ b/src/server/store-widget.ts
@@ -1,0 +1,59 @@
+import type { DatabaseSync } from "node:sqlite";
+import type { ItemType } from "./models.ts";
+import { displayTitle } from "./titles.ts";
+
+export class WidgetStore {
+  constructor(private db: DatabaseSync) {}
+
+  getTokenHash(): string | null {
+    const row = this.db.prepare("SELECT value FROM settings WHERE key = 'widget_token'").get() as
+      | { value: string }
+      | undefined;
+    return row?.value || null;
+  }
+
+  setTokenHash(hash: string | null): void {
+    if (!hash) {
+      this.db.prepare("DELETE FROM settings WHERE key = 'widget_token'").run();
+      return;
+    }
+    this.db
+      .prepare("INSERT INTO settings (key, value) VALUES ('widget_token', ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value")
+      .run(hash);
+  }
+
+  countJobs(statuses: string[]): number {
+    if (statuses.length === 0) return 0;
+    const placeholders = statuses.map(() => "?").join(", ");
+    const row = this.db.prepare(`SELECT COUNT(*) AS n FROM jobs WHERE status IN (${placeholders})`).get(...statuses) as { n: number };
+    return row.n;
+  }
+
+  countReviews(status: string): number {
+    return (this.db.prepare("SELECT COUNT(*) AS n FROM reviews WHERE status = ?").get(status) as { n: number }).n;
+  }
+
+  countOpenSuggestions(): number {
+    return (this.db.prepare("SELECT COUNT(*) AS n FROM suggestions WHERE dismissed = 0 AND (forced = 1 OR actions_json != '[]')").get() as { n: number }).n;
+  }
+
+  countLibraryByType(type: ItemType): number {
+    return (this.db.prepare("SELECT COUNT(*) AS n FROM library_items WHERE type = ?").get(type) as { n: number }).n;
+  }
+
+  lastJobError(): string | null {
+    const row = this.db.prepare("SELECT error FROM jobs WHERE status = 'failed' AND error IS NOT NULL ORDER BY id DESC LIMIT 1").get() as { error: string | null } | undefined;
+    return row?.error ?? null;
+  }
+
+  getRunningJob(): { displayTitle: string; phase: string | null; progress: number } | null {
+    const row = this.db.prepare(`SELECT j.phase, j.progress, i.title, i.series_title AS seriesTitle,
+      i.season_number AS seasonNumber, i.episode_number AS episodeNumber
+      FROM jobs j JOIN library_items i ON i.id = j.item_id
+      WHERE j.status = 'running' ORDER BY j.id DESC LIMIT 1`).get() as
+      | { phase: string | null; progress: number; title: string; seriesTitle: string | null; seasonNumber: number | null; episodeNumber: number | null }
+      | undefined;
+    if (!row) return null;
+    return { displayTitle: displayTitle(row), phase: row.phase, progress: Number(row.progress ?? 0) };
+  }
+}

--- a/src/server/store.ts
+++ b/src/server/store.ts
@@ -8,7 +8,7 @@ import { explainSuggestion } from "./suggest.ts";
 import { defaultSettings, type Settings, type User } from "./types.ts";
 import { hashPassword, verifyPassword } from "./passwords.ts";
 import { decryptSecret, encryptSecret, loadSecretKey } from "./secrets.ts";
-import type { ArrInstance, ArrKind, ItemType, LibraryItem, PlayerInstance, PlayerKind } from "./models.ts";
+import type { ArrInstance, ArrKind, ExclusionKind, ItemType, LibraryItem, PlayerInstance, PlayerKind } from "./models.ts";
 import {
   isJobPhase,
   jobPhaseLabel,
@@ -17,11 +17,17 @@ import {
   type ReviewPhase,
   type ReviewStatus,
 } from "./progress.ts";
+import { ExclusionStore } from "./store-exclusions.ts";
+import { HistoryStore } from "./store-history.ts";
+import { WidgetStore } from "./store-widget.ts";
 
 export class Store {
   readonly db: DatabaseSync;
   readonly dataDir: string;
   private readonly secretKey: Buffer;
+  private readonly exclusions: ExclusionStore;
+  private readonly history: HistoryStore;
+  private readonly widget: WidgetStore;
 
   constructor(dataDir: string) {
     this.dataDir = dataDir;
@@ -31,6 +37,9 @@ export class Store {
     this.db.exec("PRAGMA journal_mode = WAL");
     this.db.exec("PRAGMA foreign_keys = ON");
     this.migrate();
+    this.exclusions = new ExclusionStore(this.db);
+    this.history = new HistoryStore(this.db);
+    this.widget = new WidgetStore(this.db);
   }
 
   close(): void {
@@ -159,6 +168,7 @@ export class Store {
     this.ensureColumn("library_items", "episode_number", "INTEGER");
     this.ensureColumn("library_items", "series_id", "INTEGER");
     this.ensureColumn("library_items", "poster_remote_url", "TEXT");
+    this.ensureColumn("library_items", "tags_json", "TEXT NOT NULL DEFAULT '[]'");
     this.ensureColumn("inspections", "source_sig", "TEXT");
     this.ensureColumn("jobs", "phase", "TEXT");
     this.ensureColumn("jobs", "eta_sec", "REAL");
@@ -339,14 +349,16 @@ export class Store {
     this.db.prepare("DELETE FROM arr_instances WHERE id = ?").run(id);
   }
 
-  upsertLibraryItem(item: Omit<LibraryItem, "id" | "instanceName" | "instanceKind">): LibraryItem {
+  upsertLibraryItem(
+    item: Omit<LibraryItem, "id" | "instanceName" | "instanceKind" | "tags"> & { tags?: string[] },
+  ): LibraryItem {
     this.db
       .prepare(
         `INSERT INTO library_items (
           instance_id, external_id, type, title, series_title, path, folder_path,
           quality, video_codec, resolution, hdr, size, readable, path_error, updated_at,
-          season_number, episode_number, series_id, poster_remote_url
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          season_number, episode_number, series_id, poster_remote_url, tags_json
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(instance_id, type, external_id) DO UPDATE SET
           title = excluded.title,
           series_title = excluded.series_title,
@@ -363,7 +375,8 @@ export class Store {
           season_number = excluded.season_number,
           episode_number = excluded.episode_number,
           series_id = excluded.series_id,
-          poster_remote_url = excluded.poster_remote_url`,
+          poster_remote_url = excluded.poster_remote_url,
+          tags_json = excluded.tags_json`,
       )
       .run(
         item.instanceId,
@@ -385,6 +398,7 @@ export class Store {
         item.episodeNumber,
         item.seriesId,
         item.posterRemoteUrl ?? null,
+        JSON.stringify(item.tags ?? []),
       );
     const saved = this.getLibraryItemByExternal(item.instanceId, item.type, item.externalId);
     if (!saved) throw new Error("failed to upsert library item");
@@ -820,38 +834,23 @@ export class Store {
   }
 
   addHistory(itemId: number | null, title: string, action: string, detail?: string): void {
-    this.db
-      .prepare("INSERT INTO history (item_id, title, action, detail, created_at) VALUES (?, ?, ?, ?, ?)")
-      .run(itemId, title, action, detail ?? null, new Date().toISOString());
+    this.history.add(itemId, title, action, detail);
   }
 
   listHistory(): Array<Record<string, unknown>> {
-    return this.db
-      .prepare("SELECT id, item_id AS itemId, title, action, detail, created_at AS createdAt FROM history ORDER BY id DESC")
-      .all() as Array<Record<string, unknown>>;
+    return this.history.list();
   }
 
-  addExclusion(kind: string, value: string): void {
-    this.db.prepare("INSERT INTO exclusions (kind, value) VALUES (?, ?)").run(kind, value);
+  addExclusion(kind: ExclusionKind, value: string): void {
+    this.exclusions.add(kind, value);
   }
 
-  listExclusions(): Array<{ id: number; kind: string; value: string }> {
-    return this.db.prepare("SELECT id, kind, value FROM exclusions").all() as Array<{
-      id: number;
-      kind: string;
-      value: string;
-    }>;
+  listExclusions(): Array<{ id: number; kind: ExclusionKind; value: string }> {
+    return this.exclusions.list();
   }
 
-  isExcluded(item: { title: string; path: string; quality: string | null }): boolean {
-    for (const ex of this.listExclusions()) {
-      const v = ex.value.toLowerCase();
-      if (ex.kind === "title" && item.title.toLowerCase().includes(v)) return true;
-      if (ex.kind === "path" && item.path.toLowerCase().includes(v)) return true;
-      if (ex.kind === "profile" && (item.quality ?? "").toLowerCase().includes(v)) return true;
-      if (ex.kind === "tag" && item.title.toLowerCase().includes(v)) return true;
-    }
-    return false;
+  isExcluded(item: Pick<LibraryItem, "title" | "path" | "quality" | "tags">): boolean {
+    return this.exclusions.matches(item);
   }
 
   createPlayer(input: { kind: PlayerKind; name: string; url: string; token: string; enabled?: boolean }): PlayerInstance {
@@ -890,88 +889,35 @@ export class Store {
   }
 
   getWidgetTokenHash(): string | null {
-    const row = this.db.prepare("SELECT value FROM settings WHERE key = 'widget_token'").get() as
-      | { value: string }
-      | undefined;
-    return row?.value || null;
+    return this.widget.getTokenHash();
   }
 
   setWidgetTokenHash(hash: string | null): void {
-    if (!hash) {
-      this.db.prepare("DELETE FROM settings WHERE key = 'widget_token'").run();
-      return;
-    }
-    this.db
-      .prepare("INSERT INTO settings (key, value) VALUES ('widget_token', ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value")
-      .run(hash);
+    this.widget.setTokenHash(hash);
   }
 
   countJobs(statuses: string[]): number {
-    if (statuses.length === 0) return 0;
-    const placeholders = statuses.map(() => "?").join(", ");
-    const row = this.db.prepare(`SELECT COUNT(*) AS n FROM jobs WHERE status IN (${placeholders})`).get(...statuses) as {
-      n: number;
-    };
-    return row.n;
+    return this.widget.countJobs(statuses);
   }
 
   countReviews(status: string): number {
-    const row = this.db.prepare("SELECT COUNT(*) AS n FROM reviews WHERE status = ?").get(status) as { n: number };
-    return row.n;
+    return this.widget.countReviews(status);
   }
 
   countOpenSuggestions(): number {
-    const row = this.db
-      .prepare(
-        `SELECT COUNT(*) AS n FROM suggestions
-         WHERE dismissed = 0 AND (forced = 1 OR actions_json != '[]')`,
-      )
-      .get() as { n: number };
-    return row.n;
+    return this.widget.countOpenSuggestions();
   }
 
   countLibraryByType(type: ItemType): number {
-    const row = this.db.prepare("SELECT COUNT(*) AS n FROM library_items WHERE type = ?").get(type) as { n: number };
-    return row.n;
+    return this.widget.countLibraryByType(type);
   }
 
   lastJobError(): string | null {
-    const row = this.db
-      .prepare("SELECT error FROM jobs WHERE status = 'failed' AND error IS NOT NULL ORDER BY id DESC LIMIT 1")
-      .get() as { error: string | null } | undefined;
-    return row?.error ?? null;
+    return this.widget.lastJobError();
   }
 
   getRunningJob(): { displayTitle: string; phase: string | null; progress: number } | null {
-    const row = this.db
-      .prepare(
-        `SELECT j.phase, j.progress, i.title, i.series_title AS seriesTitle,
-                i.season_number AS seasonNumber, i.episode_number AS episodeNumber
-         FROM jobs j JOIN library_items i ON i.id = j.item_id
-         WHERE j.status = 'running'
-         ORDER BY j.id DESC LIMIT 1`,
-      )
-      .get() as
-      | {
-          phase: string | null;
-          progress: number;
-          title: string;
-          seriesTitle: string | null;
-          seasonNumber: number | null;
-          episodeNumber: number | null;
-        }
-      | undefined;
-    if (!row) return null;
-    return {
-      displayTitle: displayTitle({
-        title: row.title,
-        seriesTitle: row.seriesTitle,
-        seasonNumber: row.seasonNumber,
-        episodeNumber: row.episodeNumber,
-      }),
-      phase: row.phase,
-      progress: Number(row.progress ?? 0),
-    };
+    return this.widget.getRunningJob();
   }
 
   countLibraryItems(instanceId: number, type: ItemType): number {
@@ -1018,13 +964,15 @@ const LIBRARY_ITEM_SQL = `
           i.season_number AS seasonNumber, i.episode_number AS episodeNumber,
           i.path, i.folder_path AS folderPath, i.quality, i.video_codec AS videoCodec,
           i.resolution, i.hdr, i.size, i.readable, i.path_error AS pathError, i.updated_at AS updatedAt,
-          i.poster_remote_url AS posterRemoteUrl`;
+          i.poster_remote_url AS posterRemoteUrl, i.tags_json AS tagsJson`;
 
-function asLibraryItem(row: LibraryItem & { readable: number | boolean }): LibraryItem {
+function asLibraryItem(row: LibraryItem & { readable: number | boolean; tagsJson?: string }): LibraryItem {
+  const { tagsJson, ...item } = row;
   return {
-    ...row,
+    ...item,
     readable: Boolean(row.readable),
     posterRemoteUrl: row.posterRemoteUrl ?? null,
+    tags: tagsJson ? JSON.parse(tagsJson) : [],
   };
 }
 

--- a/src/server/sync.test.ts
+++ b/src/server/sync.test.ts
@@ -55,6 +55,23 @@ describe("phase 2 radarr sync", () => {
     return { app, store, sync, cookie: cookieHeader(first) };
   }
 
+  it("stores Arr tags and matches tag exclusions without matching title text", async () => {
+    const { store, app, cookie } = await setup([
+      { id: 8, title: "Archive", tags: [42], movieFile: { path: "/archive.mkv", size: 10 } },
+      { id: 9, title: "Tag 42 in title", tags: [7], movieFile: { path: "/other.mkv", size: 10 } },
+    ]);
+    await app.request("/api/instances", {
+      method: "POST",
+      headers: { "content-type": "application/json", cookie },
+      body: JSON.stringify({ kind: "radarr", name: "Radarr", url: "http://radarr", apiKey: "k" }),
+    });
+    await app.request("/api/library/refresh", { method: "POST", headers: { cookie } });
+    store.addExclusion("tag", "42");
+    const [archive, titleOnly] = store.listLibraryItems("movie");
+    expect(store.isExcluded(archive)).toBe(true);
+    expect(store.isExcluded(titleOnly)).toBe(false);
+  });
+
   it("saves a Radarr instance without echoing the API key and tests the connection", async () => {
     const { app, store, cookie } = await setup([]);
     const created = await app.request("/api/instances", {

--- a/src/server/sync.ts
+++ b/src/server/sync.ts
@@ -121,6 +121,7 @@ export class LibrarySync {
         hdr: movie.hdr,
         size: movie.size,
         posterRemoteUrl: movie.posterRemoteUrl,
+        tags: movie.tags,
         readable,
         pathError: hasPath ? (readable ? null : UNREADABLE) : noFileMessage(instance.kind),
         updatedAt,

--- a/src/web/components/InspectBanner.tsx
+++ b/src/web/components/InspectBanner.tsx
@@ -27,17 +27,20 @@ export function InspectBanner() {
 
   if (progress.walking) {
     return (
-      <div className="mb-5 rounded-lg border border-amber-500/20 bg-amber-500/10 px-3 py-2 text-sm text-amber-200">
-        Movie and series lists are ready. Still reading leftover files: {progress.inspected} checked,{" "}
-        {progress.pending} left.
-        {progress.errors > 0 ? ` ${progress.errors} files could not be read.` : ""}
+      <div className="mb-6 flex items-center gap-3 rounded-2xl border border-amber-300/15 bg-amber-400/[0.06] px-4 py-3 text-sm text-amber-100 shadow-lg shadow-amber-950/10 backdrop-blur-sm">
+        <span className="h-2 w-2 animate-pulse rounded-full bg-amber-300 shadow-[0_0_12px_rgba(252,211,77,0.65)]" />
+        <span>
+          Movie and series lists are ready. Still reading leftover files: {progress.inspected} checked,{" "}
+          {progress.pending} left.
+          {progress.errors > 0 ? ` ${progress.errors} files could not be read.` : ""}
+        </span>
       </div>
     );
   }
 
   if (progress.errors > 0 && !dismissed) {
     return (
-      <div className="mb-5 flex items-center justify-between gap-3 rounded-lg border border-zinc-800 bg-zinc-900/60 px-3 py-2 text-sm text-zinc-300">
+      <div className="panel mb-6 flex items-center justify-between gap-3 px-4 py-3 text-sm text-zinc-300">
         <span>
           {progress.errors} file{progress.errors === 1 ? "" : "s"} could not be read.
         </span>

--- a/src/web/components/LibraryActions.tsx
+++ b/src/web/components/LibraryActions.tsx
@@ -41,9 +41,9 @@ export function LibraryActions({ itemId, readable, pathError, titleQuery }: Prop
     : "/suggestions";
 
   return (
-    <div className="mt-2">
+    <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1 border-t border-white/[0.055] pt-2.5">
       <button
-        className="text-xs text-amber-400 hover:text-amber-300 disabled:opacity-50"
+        className="text-xs font-medium text-amber-400 transition hover:text-amber-300 disabled:opacity-50"
         type="button"
         disabled={busy !== null || !readable}
         onClick={() => void run("force")}
@@ -51,7 +51,7 @@ export function LibraryActions({ itemId, readable, pathError, titleQuery }: Prop
         {busy === "force" ? "Forcing…" : "Force suggestion"}
       </button>
       <button
-        className="ml-3 text-xs text-amber-400 hover:text-amber-300 disabled:opacity-50"
+        className="text-xs font-medium text-amber-400 transition hover:text-amber-300 disabled:opacity-50"
         type="button"
         disabled={busy !== null || !readable}
         onClick={() => void run("stereo")}
@@ -59,14 +59,14 @@ export function LibraryActions({ itemId, readable, pathError, titleQuery }: Prop
         {busy === "stereo" ? "Adding…" : "Add stereo"}
       </button>
       {status && (
-        <div className="mt-1 text-xs text-emerald-400">
+        <div className="basis-full text-xs text-emerald-400">
           {status}{" "}
           <Link to={suggestionsTo} className="underline hover:text-emerald-300">
             Open Suggestions
           </Link>
         </div>
       )}
-      {error && <div className="mt-1 text-xs text-red-400">{error}</div>}
+      {error && <div className="basis-full text-xs text-red-400">{error}</div>}
     </div>
   );
 }

--- a/src/web/components/Shell.tsx
+++ b/src/web/components/Shell.tsx
@@ -43,15 +43,16 @@ export function Shell({ username, setupComplete, onLogout, children }: Props) {
   }
 
   return (
-    <div className="flex min-h-screen flex-col md:flex-row">
-      <header className="flex items-center justify-between border-b border-zinc-800 bg-zinc-900 px-4 py-3 md:hidden">
+    <div className="relative flex min-h-screen flex-col overflow-hidden md:flex-row">
+      <div className="pointer-events-none fixed inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-amber-300/60 to-transparent" />
+      <header className="sticky top-0 z-30 flex items-center justify-between border-b border-white/[0.08] bg-zinc-950/85 px-4 py-3 backdrop-blur-xl md:hidden">
         <div className="flex items-center gap-2">
           <LogoMark className="h-7 w-7 rounded-md" />
           <span className="font-semibold tracking-tight">Optimizarr</span>
         </div>
         <button
           type="button"
-          className="rounded-md px-3 py-1 text-sm text-zinc-300 hover:bg-zinc-800"
+          className="btn-secondary !rounded-lg !px-3 !py-1.5"
           onClick={() => setOpen((v) => !v)}
         >
           Menu
@@ -59,46 +60,57 @@ export function Shell({ username, setupComplete, onLogout, children }: Props) {
       </header>
 
       <aside
-        className={`${open ? "flex" : "hidden"} w-full flex-col border-b border-zinc-800 bg-zinc-900 md:flex md:w-56 md:border-b-0 md:border-r`}
+        className={`${open ? "flex" : "hidden"} z-20 w-full flex-col border-b border-white/[0.08] bg-zinc-950/95 backdrop-blur-xl md:fixed md:inset-y-0 md:left-0 md:flex md:w-64 md:border-b-0 md:border-r`}
       >
-        <div className="hidden items-center gap-2 px-5 py-5 md:flex">
-          <LogoMark className="h-8 w-8 rounded-md" />
+        <div className="hidden items-center gap-3 px-5 py-6 md:flex">
+          <LogoMark className="h-10 w-10 rounded-xl shadow-lg shadow-amber-950/30" />
           <div>
-            <div className="text-base font-semibold tracking-tight">Optimizarr</div>
-            <div className="text-xs text-zinc-500">Companion *arr</div>
+            <div className="text-base font-semibold tracking-[-0.02em]">Optimizarr</div>
+            <div className="mt-0.5 text-[0.66rem] font-medium uppercase tracking-[0.18em] text-zinc-600">Media control</div>
           </div>
         </div>
-        <nav className="flex flex-1 flex-col gap-0.5 p-3">
+        <div className="mx-5 hidden items-center gap-2 rounded-xl border border-emerald-400/10 bg-emerald-400/[0.04] px-3 py-2 text-xs text-zinc-400 md:flex">
+          <span className="status-dot" />
+          System online
+        </div>
+        <nav className="flex flex-1 flex-col gap-1 p-3 md:mt-4">
           {NAV.map((item) => (
             <NavLink
               key={item.to}
               to={item.to}
               onClick={() => setOpen(false)}
               className={({ isActive }) =>
-                `flex items-center gap-2.5 rounded-md px-3 py-2 text-sm ${
+                `group flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm transition ${
                   isActive
-                    ? "bg-amber-500/15 font-medium text-amber-300"
-                    : "text-zinc-300 hover:bg-zinc-800 hover:text-white"
+                    ? "border border-amber-300/10 bg-gradient-to-r from-amber-400/15 to-transparent font-medium text-amber-200 shadow-inner shadow-amber-300/[0.03]"
+                    : "border border-transparent text-zinc-400 hover:bg-white/[0.045] hover:text-zinc-100"
                 }`
               }
             >
-              <item.Icon className="h-4 w-4 shrink-0" />
+              <item.Icon className="h-[1.05rem] w-[1.05rem] shrink-0 transition group-hover:scale-105" />
               {item.label}
             </NavLink>
           ))}
         </nav>
-        <div className="border-t border-zinc-800 p-4 text-xs text-zinc-500">
-          <div className="mb-2 truncate text-zinc-300">{username}</div>
+        <div className="border-t border-white/[0.07] p-4 text-xs text-zinc-500">
+          <div className="mb-3 flex items-center gap-2.5 rounded-xl bg-white/[0.03] p-2.5">
+            <span className="flex h-7 w-7 items-center justify-center rounded-lg bg-amber-400/10 font-semibold text-amber-300">
+              {username.slice(0, 1).toUpperCase()}
+            </span>
+            <span className="min-w-0 flex-1 truncate text-zinc-300">{username}</span>
+          </div>
           {!setupComplete && <div className="mb-2 text-amber-400">Finish setup</div>}
-          <button type="button" className="text-zinc-400 hover:text-white" onClick={() => void logout()}>
+          <button type="button" className="px-2 text-zinc-500 transition hover:text-white" onClick={() => void logout()}>
             Log out
           </button>
         </div>
       </aside>
 
-      <main className="flex-1 p-5 md:p-8">
-        <InspectBanner />
-        {children}
+      <main className="relative flex-1 p-5 md:ml-64 md:p-8 lg:p-10">
+        <div className="mx-auto max-w-[92rem]">
+          <InspectBanner />
+          {children}
+        </div>
       </main>
     </div>
   );

--- a/src/web/index.css
+++ b/src/web/index.css
@@ -7,6 +7,12 @@ body,
 }
 
 body {
+  margin: 0;
+  color: #f4f4f5;
+  background:
+    radial-gradient(circle at 78% -12%, rgba(245, 158, 11, 0.12), transparent 34rem),
+    radial-gradient(circle at 12% 82%, rgba(34, 211, 238, 0.06), transparent 30rem),
+    #09090b;
   font-family:
     Inter,
     ui-sans-serif,
@@ -14,12 +20,54 @@ body {
     -apple-system,
     Segoe UI,
     sans-serif;
+  font-feature-settings: "cv02", "cv03", "cv04", "cv11";
 }
 
 .input {
-  @apply w-full rounded-lg border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-amber-400;
+  @apply w-full rounded-xl border border-white/10 bg-black/25 px-3.5 py-2.5 text-sm text-zinc-100 shadow-inner shadow-black/10 outline-none transition placeholder:text-zinc-600 focus:border-amber-400/70 focus:ring-2 focus:ring-amber-400/10;
 }
 
 .btn {
-  @apply inline-flex w-full items-center justify-center rounded-lg bg-amber-500 px-4 py-2 text-sm font-medium text-zinc-950 hover:bg-amber-400 disabled:opacity-60;
+  @apply inline-flex w-full items-center justify-center gap-2 rounded-xl border border-amber-300/20 bg-gradient-to-b from-amber-400 to-amber-500 px-4 py-2.5 text-sm font-semibold text-zinc-950 shadow-lg shadow-amber-950/20 transition hover:-translate-y-px hover:from-amber-300 hover:to-amber-400 disabled:pointer-events-none disabled:translate-y-0 disabled:opacity-50;
+}
+
+.btn-secondary {
+  @apply inline-flex items-center justify-center gap-2 rounded-xl border border-white/10 bg-white/[0.045] px-4 py-2.5 text-sm font-medium text-zinc-200 transition hover:border-white/15 hover:bg-white/[0.08] hover:text-white disabled:pointer-events-none disabled:opacity-50;
+}
+
+.page-header {
+  @apply mb-7 flex flex-wrap items-end justify-between gap-4;
+}
+
+.page-eyebrow {
+  @apply mb-1.5 text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-amber-400/80;
+}
+
+.page-title {
+  @apply text-3xl font-semibold tracking-[-0.035em] text-white md:text-4xl;
+}
+
+.page-description {
+  @apply mt-2 max-w-2xl text-sm leading-6 text-zinc-400;
+}
+
+.panel {
+  @apply rounded-2xl border border-white/[0.08] bg-zinc-900/55 shadow-xl shadow-black/10 backdrop-blur-sm;
+}
+
+.empty-panel {
+  @apply max-w-2xl rounded-2xl border border-white/[0.08] bg-zinc-900/55 p-8 shadow-xl shadow-black/10 backdrop-blur-sm md:p-10;
+}
+
+.meta-pill {
+  @apply inline-flex items-center rounded-full border border-white/[0.08] bg-white/[0.04] px-2.5 py-1 text-[0.68rem] font-medium text-zinc-400;
+}
+
+.status-dot {
+  @apply inline-block h-1.5 w-1.5 rounded-full bg-emerald-400 shadow-[0_0_10px_rgba(52,211,153,0.75)];
+}
+
+::selection {
+  color: #18181b;
+  background: #fbbf24;
 }

--- a/src/web/pages/FirstRun.tsx
+++ b/src/web/pages/FirstRun.tsx
@@ -350,13 +350,14 @@ export function AuthCard({
   children: ReactNode;
 }) {
   return (
-    <div className="flex min-h-screen items-center justify-center p-6">
-      <div className="w-full max-w-md rounded-2xl border border-zinc-800 bg-zinc-900 p-8 shadow-xl">
-        <div className="mb-6 flex items-center gap-2">
-          <span className="h-3 w-3 rounded-full bg-amber-400" />
-          <span className="font-semibold">Optimizarr</span>
+    <div className="relative flex min-h-screen items-center justify-center overflow-hidden p-6">
+      <div className="pointer-events-none absolute left-1/2 top-[-18rem] h-[38rem] w-[38rem] -translate-x-1/2 rounded-full bg-amber-400/[0.08] blur-3xl" />
+      <div className="panel relative w-full max-w-md p-8 md:p-10">
+        <div className="mb-8 flex items-center gap-3">
+          <span className="flex h-9 w-9 items-center justify-center rounded-xl border border-amber-300/20 bg-amber-400/10 text-lg font-bold text-amber-300">O</span>
+          <span className="font-semibold tracking-[-0.02em]">Optimizarr</span>
         </div>
-        <h1 className="text-xl font-semibold tracking-tight">{title}</h1>
+        <h1 className="text-2xl font-semibold tracking-[-0.035em]">{title}</h1>
         <p className="mt-2 mb-6 text-sm leading-6 text-zinc-400">{subtitle}</p>
         {children}
       </div>

--- a/src/web/pages/History.tsx
+++ b/src/web/pages/History.tsx
@@ -14,18 +14,26 @@ export function History() {
 
   return (
     <section>
-      <h1 className="text-2xl font-semibold tracking-tight">History</h1>
+      <div className="page-header">
+        <div>
+          <div className="page-eyebrow">Activity</div>
+          <h1 className="page-title">History</h1>
+          <p className="page-description">A record of finished, kept, discarded, flagged, and failed work.</p>
+        </div>
+      </div>
       {items.length === 0 ? (
-        <div className="mt-8 max-w-xl rounded-xl border border-zinc-800 bg-zinc-900/60 p-8 text-sm text-zinc-400">
+        <div className="empty-panel text-sm text-zinc-400">
           {message || "Completed jobs will be listed here."}
         </div>
       ) : (
-        <ul className="mt-6 space-y-2 text-sm">
+        <ul className="space-y-3 text-sm">
           {items.map((row) => (
-            <li key={String(row.id)} className="rounded-lg border border-zinc-800 px-4 py-3">
-              <span className="font-medium">{String(row.title)}</span>
-              <span className="ml-2 text-zinc-500">{String(row.action)}</span>
-              {row.detail ? <div className="text-xs text-zinc-500">{String(row.detail)}</div> : null}
+            <li key={String(row.id)} className="panel flex flex-wrap items-start justify-between gap-3 px-5 py-4">
+              <div>
+                <div className="font-semibold">{String(row.title)}</div>
+                {row.detail ? <div className="mt-1 text-xs text-zinc-500">{String(row.detail)}</div> : null}
+              </div>
+              <span className="meta-pill capitalize">{String(row.action)}</span>
             </li>
           ))}
         </ul>

--- a/src/web/pages/Movies.tsx
+++ b/src/web/pages/Movies.tsx
@@ -40,11 +40,15 @@ export function Movies() {
 
   return (
     <section>
-      <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
-        <h1 className="text-2xl font-semibold tracking-tight">Movies</h1>
+      <div className="page-header">
+        <div>
+          <div className="page-eyebrow">Library</div>
+          <h1 className="page-title">Movies</h1>
+          <p className="page-description">Browse synced titles, inspect their current format, and choose what Optimizarr should improve.</p>
+        </div>
         <div className="flex flex-wrap gap-2">
           <button
-            className="text-xs text-zinc-400 hover:text-zinc-200"
+            className="btn-secondary !py-2"
             type="button"
             onClick={() => setView((v) => (v === "cards" ? "list" : "cards"))}
           >
@@ -57,23 +61,25 @@ export function Movies() {
       </div>
       {error && <p className="mb-4 text-sm text-red-400">{error}</p>}
       {items.length === 0 ? (
-        <div className="max-w-xl rounded-xl border border-zinc-800 bg-zinc-900/60 p-8">
+        <div className="empty-panel">
           <p className="text-sm leading-6 text-zinc-400">{message}</p>
         </div>
       ) : view === "list" ? (
         <MovieTable items={items} />
       ) : (
-        <ul className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+        <ul className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
           {items.map((item) => (
-            <li key={item.id} className="flex gap-3 rounded-xl border border-zinc-800 bg-zinc-900/40 p-3">
-              <Poster itemId={item.id} hasPoster={item.hasPoster} alt="" className="h-28 w-[4.65rem] rounded-md" />
+            <li key={item.id} className="panel group flex gap-4 overflow-hidden p-3.5 transition hover:-translate-y-0.5 hover:border-white/[0.13] hover:bg-zinc-900/75">
+              <Poster itemId={item.id} hasPoster={item.hasPoster} alt="" className="h-32 w-[5.3rem] rounded-xl shadow-lg shadow-black/30" />
               <div className="min-w-0 flex-1">
-                <div className="font-medium">{item.title}</div>
-                <div className="mt-1 text-xs text-zinc-500">
-                  {item.instanceName} · {item.quality ?? "—"} · {item.videoCodec ?? "unknown codec"} ·{" "}
-                  {formatSize(item.size)}
+                <div className="line-clamp-2 font-semibold tracking-[-0.01em] text-zinc-100">{item.title}</div>
+                <div className="mt-2 flex flex-wrap gap-1.5">
+                  <span className="meta-pill">{item.quality ?? "Unknown quality"}</span>
+                  <span className="meta-pill">{item.videoCodec ?? "Unknown codec"}</span>
+                  <span className="meta-pill">{formatSize(item.size)}</span>
                 </div>
-                <div className="mt-1 truncate text-xs text-zinc-500" title={item.path}>
+                <div className="mt-2 text-[0.68rem] font-medium uppercase tracking-wider text-zinc-600">{item.instanceName}</div>
+                <div className="mt-1 truncate text-xs text-zinc-600" title={item.path}>
                   {item.path || "—"}
                 </div>
                 {!item.readable && item.pathError && (
@@ -96,9 +102,9 @@ export function Movies() {
 
 function MovieTable({ items }: { items: LibraryItem[] }) {
   return (
-    <div className="overflow-x-auto rounded-xl border border-zinc-800">
+    <div className="panel overflow-x-auto">
       <table className="min-w-full text-left text-sm">
-        <thead className="bg-zinc-900 text-xs uppercase tracking-wide text-zinc-500">
+        <thead className="bg-white/[0.025] text-[0.68rem] uppercase tracking-[0.14em] text-zinc-500">
           <tr>
             <th className="px-4 py-3">Title</th>
             <th className="px-4 py-3">Instance</th>
@@ -110,7 +116,7 @@ function MovieTable({ items }: { items: LibraryItem[] }) {
         </thead>
         <tbody>
           {items.map((item) => (
-            <tr key={item.id} className="border-t border-zinc-800">
+            <tr key={item.id} className="border-t border-white/[0.06] transition hover:bg-white/[0.025]">
               <td className="px-4 py-3 font-medium">{item.title}</td>
               <td className="px-4 py-3 text-zinc-400">{item.instanceName}</td>
               <td className="px-4 py-3 text-zinc-400">{item.quality ?? "—"}</td>

--- a/src/web/pages/Queue.tsx
+++ b/src/web/pages/Queue.tsx
@@ -64,14 +64,20 @@ export function Queue() {
 
   return (
     <section>
-      <h1 className="text-2xl font-semibold tracking-tight">Queue</h1>
+      <div className="page-header">
+        <div>
+          <div className="page-eyebrow">Processing</div>
+          <h1 className="page-title">Queue</h1>
+          <p className="page-description">Track each copy, remux, and encode from approval through completion.</p>
+        </div>
+      </div>
       {error && <p className="mt-4 text-sm text-red-400">{error}</p>}
       {items.length === 0 ? (
-        <div className="mt-8 max-w-xl rounded-xl border border-zinc-800 bg-zinc-900/60 p-8 text-sm text-zinc-400">
+        <div className="empty-panel text-sm text-zinc-400">
           {message || "Approved work will appear here."}
         </div>
       ) : (
-        <ul className="mt-6 space-y-2">
+        <ul className="space-y-3">
           {[...items]
             .sort((a, b) => {
               const rank = (status: string) =>
@@ -88,15 +94,15 @@ export function Queue() {
             return (
               <li
                 key={String(job.id)}
-                className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-zinc-800 px-4 py-3 text-sm"
+                className="panel flex flex-wrap items-center justify-between gap-4 px-5 py-4 text-sm transition hover:border-white/[0.12]"
               >
                 <div className="min-w-0 flex-1">
-                  <span className="font-medium">{String(job.displayTitle || job.title || "Job")}</span>
-                  <span className="ml-2 text-zinc-500">{label}</span>
+                  <div className="font-semibold tracking-[-0.01em]">{String(job.displayTitle || job.title || "Job")}</div>
+                  <div className="mt-1 text-xs font-medium uppercase tracking-wider text-zinc-500">{label}</div>
                   {showBar && pct != null && (
                     <div className="mt-2 max-w-md">
-                      <div className="h-1.5 overflow-hidden rounded-full bg-zinc-800">
-                        <div className="h-full bg-amber-400" style={{ width: `${pct}%` }} />
+                      <div className="h-2 overflow-hidden rounded-full border border-white/[0.04] bg-black/30">
+                        <div className="h-full rounded-full bg-gradient-to-r from-amber-500 to-amber-300 shadow-[0_0_14px_rgba(251,191,36,0.25)]" style={{ width: `${pct}%` }} />
                       </div>
                       <div className="mt-1 text-xs text-zinc-500">
                         {pct}%
@@ -111,7 +117,7 @@ export function Queue() {
                 </div>
                 {ACTIVE.has(status) && (
                   <button
-                    className="btn !w-auto !bg-zinc-700 !text-zinc-100"
+                    className="btn-secondary"
                     type="button"
                     disabled={busyId === job.id}
                     onClick={() => void cancel(job.id)}

--- a/src/web/pages/Review.tsx
+++ b/src/web/pages/Review.tsx
@@ -44,26 +44,32 @@ export function Review() {
 
   return (
     <section>
-      <h1 className="text-2xl font-semibold tracking-tight">Review</h1>
+      <div className="page-header">
+        <div>
+          <div className="page-eyebrow">Decision point</div>
+          <h1 className="page-title">Review</h1>
+          <p className="page-description">Compare the original with its sidecar. The library changes only after you choose Keep.</p>
+        </div>
+      </div>
       {error && <p className="mt-3 text-sm text-red-400">{error}</p>}
       {items.length === 0 ? (
-        <div className="mt-8 max-w-xl rounded-xl border border-zinc-800 bg-zinc-900/60 p-8 text-sm text-zinc-400">
+        <div className="empty-panel text-sm text-zinc-400">
           {message || "Finished sidecars wait here for Keep or Discard."}
         </div>
       ) : (
-        <div className="mt-6 space-y-4">
+        <div className="space-y-4">
           {items.map((item) => (
-            <article key={item.id} className="rounded-xl border border-zinc-800 p-5">
-              <h2 className="font-medium">{item.displayTitle || item.title}</h2>
+            <article key={item.id} className="panel overflow-hidden p-5 md:p-6">
+              <h2 className="text-lg font-semibold tracking-[-0.02em]">{item.displayTitle || item.title}</h2>
               <div className="mt-3 grid gap-3 text-sm text-zinc-400 md:grid-cols-2">
-                <div>
-                  <div className="text-xs uppercase text-zinc-500">Original</div>
+                <div className="rounded-xl border border-white/[0.06] bg-black/15 p-4">
+                  <div className="mb-2 text-[0.68rem] font-semibold uppercase tracking-[0.18em] text-zinc-500">Original</div>
                   <div>codec {item.compare.source?.codec ?? "—"}</div>
                   <div>size {item.compare.source?.size ?? "—"}</div>
                   <div className="truncate">{item.sourcePath}</div>
                 </div>
-                <div>
-                  <div className="text-xs uppercase text-zinc-500">Sidecar</div>
+                <div className="rounded-xl border border-amber-300/10 bg-amber-400/[0.035] p-4">
+                  <div className="mb-2 text-[0.68rem] font-semibold uppercase tracking-[0.18em] text-amber-300/70">Optimized sidecar</div>
                   <div>duration {item.compare.sidecar?.duration ?? "—"}s</div>
                   <div>size {item.compare.sidecar?.size ?? "—"}</div>
                   <div className="truncate">{item.sidecarPath}</div>
@@ -101,7 +107,7 @@ export function Review() {
                   {item.status === "keeping" || (busy?.id === item.id && busy.kind === "keep") ? "Keeping…" : "Keep"}
                 </button>
                 <button
-                  className="btn !w-auto !bg-zinc-700 !text-zinc-100"
+                  className="btn-secondary"
                   type="button"
                   disabled={busy?.id === item.id || item.status === "keeping"}
                   onClick={() => {

--- a/src/web/pages/Series.tsx
+++ b/src/web/pages/Series.tsx
@@ -95,26 +95,30 @@ export function Series() {
 
   return (
     <section>
-      <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
-        <h1 className="text-2xl font-semibold tracking-tight">Series</h1>
+      <div className="page-header">
+        <div>
+          <div className="page-eyebrow">Library</div>
+          <h1 className="page-title">Series</h1>
+          <p className="page-description">Move from show to season to episode without losing the source, format, or optimization controls.</p>
+        </div>
         <button className="btn !w-auto" type="button" disabled={busy} onClick={() => void refresh()}>
           {busy ? "Syncing…" : "Refresh library"}
         </button>
       </div>
       {error && <p className="mb-4 text-sm text-red-400">{error}</p>}
       {groups.length === 0 ? (
-        <div className="max-w-xl rounded-xl border border-zinc-800 bg-zinc-900/60 p-8 text-sm text-zinc-400">
+        <div className="empty-panel text-sm text-zinc-400">
           {message || "Connect Sonarr in Settings to sync your library."}
         </div>
       ) : (
-        <div className="space-y-2">
+        <div className="space-y-3">
           {groups.map((show) => {
             const seriesOpen = openSeries[show.key] ?? true;
             return (
-              <article key={show.key} className="overflow-hidden rounded-xl border border-zinc-800">
+              <article key={show.key} className="panel overflow-hidden">
                 <button
                   type="button"
-                  className="flex w-full items-center gap-3 bg-zinc-900 px-4 py-3 text-left"
+                  className="flex w-full items-center gap-4 bg-gradient-to-r from-white/[0.045] to-transparent px-4 py-3.5 text-left transition hover:bg-white/[0.055]"
                   onClick={() => setOpenSeries((s) => ({ ...s, [show.key]: !seriesOpen }))}
                 >
                   {show.posterItem && (
@@ -122,36 +126,36 @@ export function Series() {
                       itemId={show.posterItem.id}
                       hasPoster={show.posterItem.hasPoster}
                       alt=""
-                      className="h-14 w-10 rounded"
+                      className="h-16 w-11 rounded-lg shadow-md shadow-black/30"
                     />
                   )}
                   <span className="min-w-0 flex-1">
-                    <span className="font-medium">{show.title}</span>
-                    <span className="ml-2 text-xs text-zinc-500">{show.instanceName}</span>
+                    <span className="font-semibold tracking-[-0.01em]">{show.title}</span>
+                    <span className="mt-1 block text-[0.68rem] font-medium uppercase tracking-wider text-zinc-600">{show.instanceName}</span>
                   </span>
-                  <span className="text-xs text-zinc-500">
+                  <span className="meta-pill">
                     {show.seasons.reduce((n, s) => n + s.episodes.length, 0)} episodes
                   </span>
                 </button>
                 {seriesOpen && (
-                  <div className="border-t border-zinc-800">
+                  <div className="border-t border-white/[0.07]">
                     {show.seasons.map((season) => {
                       const seasonKey = `${show.key}:${season.season}`;
                       const seasonOpen = openSeason[seasonKey] ?? true;
                       return (
-                        <div key={seasonKey} className="border-t border-zinc-800/80 first:border-t-0">
+                        <div key={seasonKey} className="border-t border-white/[0.055] first:border-t-0">
                           <button
                             type="button"
-                            className="flex w-full items-center justify-between px-4 py-2 text-left text-sm text-zinc-300 hover:bg-zinc-900/80"
+                            className="flex w-full items-center justify-between px-5 py-2.5 text-left text-sm font-medium text-zinc-300 transition hover:bg-white/[0.025]"
                             onClick={() => setOpenSeason((s) => ({ ...s, [seasonKey]: !seasonOpen }))}
                           >
                             <span>{seasonLabel(season.season)}</span>
                             <span className="text-xs text-zinc-500">{season.episodes.length}</span>
                           </button>
                           {seasonOpen && (
-                            <ul className="bg-zinc-950/40">
+                            <ul className="bg-black/15">
                               {season.episodes.map((ep) => (
-                                <li key={ep.id} className="border-t border-zinc-900 px-4 py-2 text-sm">
+                                <li key={ep.id} className="border-t border-white/[0.045] px-5 py-3 text-sm transition hover:bg-white/[0.018]">
                                   <div className="flex flex-wrap items-baseline gap-2">
                                     <span className="font-mono text-xs text-amber-300">
                                       S{pad(ep.seasonNumber ?? 0)}E{pad(ep.episodeNumber ?? 0)}

--- a/src/web/pages/Settings.tsx
+++ b/src/web/pages/Settings.tsx
@@ -104,14 +104,17 @@ export function Settings() {
   }
 
   return (
-    <section className="max-w-2xl space-y-10">
-      <div>
-        <h1 className="text-2xl font-semibold tracking-tight">Settings</h1>
-        <p className="mt-1 text-sm text-zinc-500">Secrets are never shown after they are saved.</p>
+    <section className="max-w-3xl space-y-8">
+      <div className="page-header !mb-2">
+        <div>
+          <div className="page-eyebrow">Configuration</div>
+          <h1 className="page-title">Settings</h1>
+          <p className="page-description">Tune how Optimizarr inspects, processes, stores, and publishes your media. Saved secrets stay hidden.</p>
+        </div>
       </div>
 
-      <form className="space-y-4 rounded-xl border border-zinc-800 bg-zinc-900/50 p-6" onSubmit={(e) => void saveGeneral(e)}>
-        <h2 className="text-lg font-medium">General</h2>
+      <form className="panel space-y-4 p-6 md:p-7" onSubmit={(e) => void saveGeneral(e)}>
+        <h2 className="text-lg font-semibold tracking-[-0.02em]">General</h2>
         <label className="block text-sm">
           <span className="mb-1.5 block text-zinc-300">Preferred language</span>
           <select
@@ -398,7 +401,7 @@ export function Settings() {
         </button>
       </form>
 
-      <div className="space-y-4 rounded-xl border border-zinc-800 bg-zinc-900/50 p-6">
+      <div className="panel space-y-4 p-6 md:p-7">
         <h2 className="text-lg font-medium">Radarr / Sonarr</h2>
         <p className="text-sm text-zinc-500">
           Add each Arr separately. Optimizarr uses the same file paths they report. Mount the NAS at that path in this container.
@@ -528,7 +531,7 @@ export function Settings() {
         </form>
       </div>
 
-      <div className="space-y-4 rounded-xl border border-zinc-800 bg-zinc-900/50 p-6">
+      <div className="panel space-y-4 p-6 md:p-7">
         <h2 className="text-lg font-medium">Media players</h2>
         <p className="text-sm text-zinc-500">
           Add Plex and Jellyfin separately. Tokens are saved and never shown again.
@@ -661,7 +664,7 @@ export function Settings() {
         </form>
       </div>
 
-      <form className="space-y-4 rounded-xl border border-zinc-800 bg-zinc-900/50 p-6" onSubmit={(e) => void saveAccount(e)}>
+      <form className="panel space-y-4 p-6 md:p-7" onSubmit={(e) => void saveAccount(e)}>
         <h2 className="text-lg font-medium">Account</h2>
         <label className="block text-sm">
           <span className="mb-1.5 block text-zinc-300">Username</span>
@@ -694,7 +697,7 @@ export function Settings() {
         </button>
       </form>
 
-      <div className="space-y-3 rounded-xl border border-zinc-800 bg-zinc-900/50 p-6">
+      <div className="panel space-y-3 p-6 md:p-7">
         <h2 className="text-lg font-medium">Homepage widget</h2>
         <p className="text-sm text-zinc-500">
           Homepage polls a stats-only URL. It cannot use your login cookie, so create a widget key and put it in{" "}

--- a/src/web/pages/Suggestions.tsx
+++ b/src/web/pages/Suggestions.tsx
@@ -132,10 +132,11 @@ export function Suggestions() {
 
   return (
     <section>
-      <div className="mb-4 flex flex-wrap items-end justify-between gap-3">
+      <div className="page-header">
         <div>
-          <h1 className="text-2xl font-semibold tracking-tight">Suggestions</h1>
-          <p className="mt-1 text-sm text-zinc-500">
+          <div className="page-eyebrow">Opportunities</div>
+          <h1 className="page-title">Suggestions</h1>
+          <p className="page-description">
             Approve work here. Queued items run in{" "}
             <Link to="/queue" className="text-amber-400 hover:text-amber-300">
               Queue
@@ -157,7 +158,7 @@ export function Suggestions() {
             {busyId === "all" ? "Queuing…" : `Add selected to queue${selectedIds.length ? ` (${selectedIds.length})` : ""}`}
           </button>
           <button
-            className="btn !w-auto !bg-zinc-700 !text-zinc-100"
+            className="btn-secondary"
             type="button"
             disabled={busyId !== null || items.length === 0}
             onClick={() => void queueMany(items.map((i) => i.id))}
@@ -166,23 +167,23 @@ export function Suggestions() {
           </button>
         </div>
       </div>
-      <div className="flex flex-wrap gap-3">
+      <div className="panel flex flex-wrap items-center gap-3 p-3.5">
         <input
           className="input max-w-xs"
           placeholder="Search show, episode, or codec"
           value={q}
           onChange={(e) => setQ(e.target.value)}
         />
-        <label className="flex items-center gap-2 text-sm text-zinc-300">
+        <label className="flex items-center gap-2 rounded-lg px-2 text-sm text-zinc-300">
           <input type="checkbox" checked={overCap} onChange={(e) => setOverCap(e.target.checked)} />
           Over size cap
         </label>
-        <label className="flex items-center gap-2 text-sm text-zinc-300">
+        <label className="flex items-center gap-2 rounded-lg px-2 text-sm text-zinc-300">
           <input type="checkbox" checked={extraTracks} onChange={(e) => setExtraTracks(e.target.checked)} />
           Extra tracks
         </label>
         <button
-          className="text-xs text-zinc-400 hover:text-zinc-200"
+          className="btn-secondary ml-auto !py-2"
           type="button"
           onClick={() => setView((v) => (v === "cards" ? "list" : "cards"))}
         >
@@ -192,13 +193,13 @@ export function Suggestions() {
       {error && <p className="mt-4 text-sm text-red-400">{error}</p>}
       {status && <p className="mt-4 text-sm text-emerald-400">{status}</p>}
       {items.length === 0 ? (
-        <div className="mt-8 max-w-xl rounded-xl border border-zinc-800 bg-zinc-900/60 p-8">
+        <div className="empty-panel mt-6">
           <p className="text-sm text-zinc-400">{message || "No suggestions."}</p>
         </div>
       ) : (
-        <ul className={view === "cards" ? "mt-6 grid gap-3 sm:grid-cols-1 xl:grid-cols-2" : "mt-6 space-y-3"}>
+        <ul className={view === "cards" ? "mt-5 grid gap-4 sm:grid-cols-1 xl:grid-cols-2" : "mt-5 space-y-3"}>
           {items.map((item) => (
-            <li key={item.id} className="rounded-xl border border-zinc-800 bg-zinc-900/40 p-4">
+            <li key={item.id} className="panel p-4 transition hover:border-white/[0.12] hover:bg-zinc-900/70">
               <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
                 <label className="flex min-w-0 flex-1 items-start gap-3">
                   <input
@@ -211,11 +212,11 @@ export function Suggestions() {
                     itemId={item.itemId}
                     hasPoster={item.hasPoster}
                     alt=""
-                    className="h-20 w-[3.35rem] rounded-md"
+                    className="h-24 w-16 rounded-xl shadow-md shadow-black/30"
                   />
                   <span className="min-w-0">
-                    <span className="block font-medium">{item.displayTitle || item.title}</span>
-                    <span className="block text-xs text-zinc-500">{item.instanceName}</span>
+                    <span className="block font-semibold tracking-[-0.01em]">{item.displayTitle || item.title}</span>
+                    <span className="mt-1 block text-[0.68rem] font-medium uppercase tracking-wider text-zinc-600">{item.instanceName}</span>
                     {item.reasons && item.reasons.length > 0 ? (
                       <ul className="mt-1 space-y-0.5 text-sm text-zinc-300">
                         {item.reasons.map((reason) => (
@@ -227,9 +228,9 @@ export function Suggestions() {
                         Plan: {item.actions.join(", ") || "none"}
                       </span>
                     )}
-                    <div className="mt-2 grid gap-2 text-xs text-zinc-500 sm:grid-cols-2">
-                      <div>
-                        <div className="font-medium text-zinc-400">Now</div>
+                    <div className="mt-3 grid gap-2 text-xs text-zinc-500 sm:grid-cols-2">
+                      <div className="rounded-xl border border-white/[0.06] bg-black/15 p-3">
+                        <div className="mb-1 font-semibold uppercase tracking-wider text-zinc-500">Now</div>
                         <div>
                           {item.now?.codec || item.videoCodec || "unknown codec"}
                           {item.now?.quality || item.quality ? ` · ${item.now?.quality || item.quality}` : ""}
@@ -239,8 +240,8 @@ export function Suggestions() {
                             : ""}
                         </div>
                       </div>
-                      <div>
-                        <div className="font-medium text-zinc-400">After</div>
+                      <div className="rounded-xl border border-amber-300/10 bg-amber-400/[0.035] p-3">
+                        <div className="mb-1 font-semibold uppercase tracking-wider text-amber-300/70">After</div>
                         <div>
                           {item.after?.codec || "—"}
                           {item.after?.sizeBytes != null ? ` · ${formatSize(item.after.sizeBytes)}` : ""}
@@ -262,7 +263,7 @@ export function Suggestions() {
                     {busyId === item.id ? "Adding…" : "Add to queue"}
                   </button>
                   <button
-                    className="btn !w-auto !bg-zinc-700 !text-zinc-100"
+                    className="btn-secondary"
                     type="button"
                     disabled={busyId !== null}
                     onClick={() => {


### PR DESCRIPTION
## What Changed

- stage cross-filesystem Keep replacements beside the library file before the atomic rename
- record changed-file probe failures instead of reusing stale inspection metadata
- keep reviews pending when Discard cannot delete a sidecar
- sync and persist Radarr/Sonarr tags, validate exclusion kinds, and match tag exclusions against tags
- move exclusion, history, and Homepage persistence into focused internal modules
- make the ffmpeg progress fixture write synchronously to its simulated progress pipe
- replace the generic application styling with a cohesive responsive visual system
- refine navigation, library cards, suggestions, queue progress, review comparisons, history, settings, and authentication

## Why

The repository evaluation found two paths that could report success after an operation failed, a cross-device replacement path that could overwrite the original during an interrupted copy, incorrect tag exclusion behavior, and unrelated persistence responsibilities concentrated in `store.ts`.

## Impact

Keep preserves the original if a cross-device copy fails. Failed inspections cannot generate plans from stale media metadata. Discard reports filesystem failures. Tag exclusions now use Arr tags instead of title text.

The interface now uses consistent page hierarchy, controls, panels, metadata treatments, and responsive navigation while preserving existing workflows.

## Validation

- `npm test` — 137 tests passed
- `npm run build` — passed
- `git diff --check` — passed

Strict TypeScript compilation still reports the repository's pre-existing Hono, SQLite assertion, test helper, storage narrowing, and nullable Settings errors.
